### PR TITLE
feat(app): save user with prescriptions

### DIFF
--- a/apps/app-mobile/app/add.tsx
+++ b/apps/app-mobile/app/add.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, Alert } from 'react-native';
+import { useRouter } from 'expo-router';
 import { supabase } from '../lib/supabase';
 
 export default function Add() {
@@ -8,11 +9,26 @@ export default function Add() {
   const [dosage, setDosage] = useState('');
   const [frequency, setFrequency] = useState('');
   const [category, setCategory] = useState<'medication' | 'supply'>('medication');
+  const router = useRouter();
 
   const save = async () => {
-    const { error } = await supabase.from('prescriptions').insert({ name, dosage, frequency, category });
+    const { data } = await supabase.auth.getSession();
+    const session = data.session;
+    if (!session) {
+      Alert.alert('Error', 'No session found');
+      return;
+    }
+    const { error } = await supabase
+      .from('prescriptions')
+      .insert({ name, dosage, frequency, category, user_id: session.user.id });
     if (error) Alert.alert('Error', error.message);
-    else Alert.alert('Saved', 'Prescription added');
+    else {
+      setName('');
+      setDosage('');
+      setFrequency('');
+      setCategory('medication');
+      router.replace('/');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- fetch current auth session and include `user_id` when inserting prescriptions
- clear form and navigate home after saving

## Testing
- `pnpm exec eslint apps/app-mobile/app/add.tsx --ext .ts,.tsx --no-warn-ignored --max-warnings 0`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f61adba788326bb7a09af6fe0832c