### PR TITLE
Use expo_push_token in push token upsert

### DIFF
--- a/apps/app-mobile/src/api/notifications.ts
+++ b/apps/app-mobile/src/api/notifications.ts
@@ -17,7 +17,9 @@ export async function registerPushToken() {
   const token = tokenData.data;
   const { data: u } = await supabase.auth.getUser();
   if (u?.user && token) {
-    await supabase.from('user_push_tokens').upsert({ user_id: u.user.id, token }, { onConflict: 'user_id' });
+    await supabase
+      .from('user_push_tokens')
+      .upsert({ user_id: u.user.id, expo_push_token: token }, { onConflict: 'user_id,expo_push_token' });
   }
   return token;
 }


### PR DESCRIPTION
## Summary
- send Expo push tokens using `expo_push_token` field
- match upsert conflict handling to `user_push_tokens` unique constraint

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a07050de588326bc39bd56b3ec44fc