### PR TITLE
refactor: centralize push token registration

### DIFF
--- a/apps/app-mobile/app/_layout.tsx
+++ b/apps/app-mobile/app/_layout.tsx
@@ -1,8 +1,5 @@
 import { Stack } from "expo-router";
-import { useEffect } from "react";
-import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
-import { supabase } from "../src/api/supabase";
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -12,32 +9,6 @@ Notifications.setNotificationHandler({
   }),
 });
 export default function Layout() {
-  useEffect(() => {
-    async function register() {
-      if (!Device.isDevice) return;
-      const { status: existingStatus } =
-        await Notifications.getPermissionsAsync();
-      let finalStatus = existingStatus;
-      if (existingStatus !== "granted") {
-        const { status } = await Notifications.requestPermissionsAsync();
-        finalStatus = status;
-      }
-      if (finalStatus !== "granted") return;
-      const token = (await Notifications.getExpoPushTokenAsync()).data;
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (user) {
-        await supabase
-          .from("user_push_tokens")
-          .upsert(
-            { user_id: user.id, expo_push_token: token },
-            { onConflict: "user_id,expo_push_token" },
-          );
-      }
-    }
-    register();
-  }, []);
 
   return (
     <Stack screenOptions={{ headerShown: true }}>

--- a/apps/app-mobile/app/index.tsx
+++ b/apps/app-mobile/app/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { View, Text, FlatList, RefreshControl } from "react-native";
 import { Link } from "expo-router";
 import { usePrescriptions } from "../src/hooks/usePrescriptions";
-import { registerPushToken } from "../src/api/notifications";
 import { Card } from "../src/ui/components/Card";
 import { colors, type, spacing } from "../src/ui/theme";
 import { supabase } from "../src/api/supabase";
@@ -12,7 +11,6 @@ export default function HomeScreen() {
   const [threshold, setThreshold] = useState(5);
 
   useEffect(() => {
-    registerPushToken().catch(() => {});
     (async () => {
       const { data: u } = await supabase.auth.getUser();
       if (!u?.user) return;

--- a/apps/app-mobile/index.js
+++ b/apps/app-mobile/index.js
@@ -1,1 +1,4 @@
 import 'expo-router/entry';
+import { registerPushToken } from './src/api/notifications';
+
+registerPushToken().catch(() => {});


### PR DESCRIPTION
## Summary
- remove inline push token registration from layout and home screen
- invoke shared `registerPushToken` helper on app launch

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a0715d2e9083269314cfca9161341a