### PR TITLE
Fetch low stock threshold from user settings

### DIFF
--- a/apps/app-mobile/app/inventory.tsx
+++ b/apps/app-mobile/app/inventory.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View, Text, FlatList, TextInput } from "react-native";
 import { supabase } from "../src/api/supabase";
 import { usePrescriptions } from "../src/hooks/usePrescriptions";
@@ -11,7 +11,20 @@ export default function Inventory() {
   const { data, reload } = usePrescriptions();
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [busyId, setBusyId] = useState<string | null>(null);
-  const threshold = 5;
+  const [threshold, setThreshold] = useState(5);
+
+  useEffect(() => {
+    (async () => {
+      const { data: u } = await supabase.auth.getUser();
+      if (!u?.user) return;
+      const { data } = await supabase
+        .from("user_settings")
+        .select("low_stock_threshold")
+        .eq("user_id", u.user.id)
+        .single();
+      if (data?.low_stock_threshold) setThreshold(data.low_stock_threshold);
+    })();
+  }, []);
 
   const apply = async (id: string) => {
     const newQty = Number(edits[id] ?? "");


### PR DESCRIPTION
## Summary
- fetch `low_stock_threshold` from `user_settings` for current user in inventory screen

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a0729bba3483268eb49d66ac2e8eaf