### PR TITLE
docs: add dev client preview link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # MediTrack Diabetes
 
-Repo scaffold optimized for **Supabase + Resend + VS Code** with an **Expo (React Native)** mobile client.  
+[Start Expo Go](pnpm --filter app-mobile start)
+[Start development client](pnpm --filter app-mobile start -- --dev-client --tunnel)
+
+Repo scaffold optimized for **Supabase + Resend + VS Code** with an **Expo (React Native)** mobile client.
 Owner: `hivoltgdevelopment` • Date: 2025-08-14
 
 ## Stack


### PR DESCRIPTION
## Summary
- add preview link for development client in README

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a079fbab508326be6e3b3ce1820efd